### PR TITLE
Backend loads environment variables from project root .env file

### DIFF
--- a/.env.EXAMPLE
+++ b/.env.EXAMPLE
@@ -1,3 +1,7 @@
+#Database Options
 DATABASE_USER=pim_user
 DATABASE_PASSWORD=pim_password
 DATABASE_NAME=pim
+
+#Backend Options
+BACKEND_PORT=3000

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,12 +1,15 @@
 const express = require('express')
+const app = express();
 
-const app = express()
-const port = 3000
+// Load the environment variables from the project root directory (Parent of the current directory). This only needs to be ran once for the entire project.
+require('dotenv').config({ path: '../.env'});
 
 app.get('/', (req, res) => {
   res.send('Hello World!')
 })
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
+//The backend should be listening on port 3000 within its container, but the container's port 3000 is mapped externally to 3001.
+// TL;DR the backend is running on port 3001 on the host machine. 
+app.listen(process.env.BACKEND_PORT, () => {
+  console.log(`Example app listening on port ${process.env.BACKEND_PORT}`)
 })

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "nodemon": "^3.0.1"
       }
@@ -224,6 +225,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/ee-first": {
@@ -1162,6 +1174,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "nodemon": "^3.0.1"
   }


### PR DESCRIPTION
Closes #3. Added a line to import the environment variables stored in the .env file in the project root directory into the backend on startup.

To access an environment variable, use `process.env.<VARIABLE NAME>`.