### PR TITLE
Changed the way packages are installed

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "predev": "npm i",
     "dev": "nodemon index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "predev": "npm i",
+    "predev": "npm ci",
     "dev": "nodemon index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
+    "prestart": "npm i",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "prestart": "npm i",
+    "prestart": "npm ci",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
Delete the node_modules folder in both the frontend and the backend. Now when the app runs, it should run `npm ci` on its own. You should not ever need to run `npm i` unless you're installing a package with `npm i --save <package-name>`. Every time the program runs, it will reinstall node_modules. This way, whenever we add a new package the container will install the correct package for its architecture. 

The alternative to doing a clean install at runtime is only installing packages that havent been installed yet. However, that would mean when you run `npm i --save <package>` you would have to delete that package from node_modules (or the entire node_modules directory) so that the container installs the correct package for its architecture. 