### PR TITLE
24 add jwt

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,3 +1,4 @@
 #Backend Options
 BACKEND_PORT=3000
 DATABASE_URL=postgres://pim_user:pim_password@database:5432/pim
+JWT_SECRET=oIAea3K2KQ7xXVuyq7pmFFVVBMp86UiT

--- a/backend/controllers/AuthController.js
+++ b/backend/controllers/AuthController.js
@@ -1,0 +1,30 @@
+const jwt = require('jsonwebtoken');
+
+// This middleware will be used to sign the token after a user logs in
+const signToken = async (req, res, next) => {
+  // Sign the token with JWT_SECRET
+  const token = jwt.sign(res.locals.vendor, process.env.JWT_SECRET);
+  // Return the token in a cookie
+  res.cookie('auth', token, {httpOnly: true, secure: false});
+
+  next();
+};
+
+// This middleware will be used to verify the token sent by the client
+const verifyToken = async (req, res, next) => {
+  // Retrieve the token from the cookie
+  const token = req.cookies.auth;
+
+  // Verify the token with JWT_SECRET
+  jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
+    if (err) {
+      res.status(401).json({message: 'Unauthorized'});
+    } else {
+      // Add the decoded object to res.locals
+      res.locals.vendor = decoded;
+      next();
+    }
+  });
+};
+
+module.exports = {signToken, verifyToken};

--- a/backend/controllers/VendorController.js
+++ b/backend/controllers/VendorController.js
@@ -22,22 +22,17 @@ const getVendor = async (req, res, next) => {
   }
 };
 
-// Middleware to authenticate the vendor
+// Middleware to verify the password of the vendor
 const authenticateVendor = async (req, res, next) => {
   try {
     const vendor = res.locals.data;
     const match = await bcrypt.compare(req.body.password, vendor.password);
+
+    // If passwords match, pass vendor object without password
     if (match) {
-      // If the password matches, store a success message and relevant vendor data
-      res.locals.data = {
-        status: 'success',
-        message: 'Successful login.',
-        vendorDetails: {
-          id: vendor.id,
-          email: vendor.email,
-          // TODO: Include any other vendor details we need
-        },
-      };
+      res.locals.vendor = vendor;
+      delete res.locals.vendor['password'];
+
       next();
     } else {
       res.status(401).json({message: 'Incorrect email or password.'});
@@ -174,8 +169,7 @@ const getEventRequest = async (req, res, next) => {
       console.error(err);
       res.status(500).json({error: 'Internal Server Error'});
     }
-  }
-  else if (vendorId && eventId) {
+  } else if (vendorId && eventId) {
     try {
       const eventRequest = db.oneOrNone(
           'SELECT * FROM Event_Requests WHERE vendor_id = $1 AND event_id = $2',
@@ -192,8 +186,7 @@ const getEventRequest = async (req, res, next) => {
       console.error(err);
       res.status(500).json({error: 'Internal Server Error'});
     }
-  }
-  else {
+  } else {
     res.status(400).json({error: 'Missing required fields'});
   }
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,16 +5,24 @@ if (require('dotenv').config().parsed === undefined) {
 
 // Import the database object from the database.js file
 const db = require('./database');
-const cors = require('cors');
+
 // Import Express and initialize our app
 const express = require('express');
 const app = express();
 
-const errorHandler = require('errorhandler');
-app.use(errorHandler({dumbExceptions: true, showStack: true}), cors());
-
 // Parse Json requests
 app.use(express.json());
+
+const errorHandler = require('errorhandler');
+app.use(errorHandler({dumbExceptions: true, showStack: true}));
+
+// Allows cross origin requests
+const cors = require('cors');
+app.use(cors());
+
+// Parses cookies attached to the client request object
+const cookieParser = require('cookie-parser');
+app.use(cookieParser());
 
 // Import router objects and direct the app to use them
 const VendorRouter = require('./routes/VendorRouter');

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,11 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "errorhandler": "^1.5.1",
         "eslint-config-google": "^0.14.0",
         "express": "^4.18.2",
+        "jsonwebtoken": "^9.0.2",
         "nodemon": "^3.0.1",
         "pg-promise": "^11.5.4"
       },
@@ -485,6 +487,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
@@ -651,6 +658,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -761,6 +788,14 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2102,6 +2137,51 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2136,10 +2216,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,11 +14,13 @@
   "license": "ISC",
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "errorhandler": "^1.5.1",
     "eslint-config-google": "^0.14.0",
     "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
     "nodemon": "^3.0.1",
     "pg-promise": "^11.5.4"
   },

--- a/backend/routes/VendorRouter.js
+++ b/backend/routes/VendorRouter.js
@@ -11,9 +11,13 @@ const {
   updateVendor,
 } = require('../controllers/VendorController');
 const sendSuccessResponse = require('../middleware/successResponse');
+const {
+  verifyToken,
+  signToken,
+} = require('../controllers/AuthController');
 
 // Logs in vendor
-router.post('/login', getVendor, authenticateVendor, sendSuccessResponse);
+router.post('/login', getVendor, authenticateVendor, signToken, sendSuccessResponse);
 
 // Fetches all vendors
 router.get('/', getVendors, sendSuccessResponse);
@@ -33,6 +37,6 @@ router.post('/events/request', createEventRequest, sendSuccessResponse);
 router.get('/events/request', getEventRequest, sendSuccessResponse);
 
 // Edit vendor by id
-router.put('/:vendorId', updateVendor, sendSuccessResponse);
+router.put('/:vendorId', verifyToken, updateVendor, sendSuccessResponse);
 
 module.exports = router;

--- a/backend/routes/VendorRouter.js
+++ b/backend/routes/VendorRouter.js
@@ -9,6 +9,7 @@ const {
   createEventRequest,
   getEventRequest,
   updateVendor,
+  updateAuthenticatedVendor,
 } = require('../controllers/VendorController');
 const sendSuccessResponse = require('../middleware/successResponse');
 const {
@@ -37,6 +38,10 @@ router.post('/events/request', createEventRequest, sendSuccessResponse);
 router.get('/events/request', getEventRequest, sendSuccessResponse);
 
 // Edit vendor by id
+// This probably should be an admin-protected route. How does that work?
 router.put('/:vendorId', verifyToken, updateVendor, sendSuccessResponse);
+
+// Route for vendor to update themself. ID is retrieved from the token.
+router.put('/', verifyToken, updateAuthenticatedVendor, sendSuccessResponse);
 
 module.exports = router;


### PR DESCRIPTION
Added JWT authentication to the vendor login route. 

When a vendor logs in, upon successful password match, a cookie is created called `auth` which stores the database object for the user. Any route that needs to be protected can use the `verifyToken` middleware, which checks the signature of the cookie to see if it has been tampered with.

JWT's are encoded, not encrypted. This means that the data can be read and modified by anyone - however, they cannot update the signature of the token without the secret stored in the backend. So, for any instance where the cookie data needs to be read, the validity of the token needs to be confirmed first.

This is only for Vendors, not for the admin routes. However, the implementation will be similar with `verifyAdminToken` and `signAdminToken` functions. 

- [x] Closes #18 
- [x] Closes #24 