### PR TITLE
Auth admin jwt

### DIFF
--- a/backend/controllers/AdminController.js
+++ b/backend/controllers/AdminController.js
@@ -1,0 +1,42 @@
+const express = require('express');
+// const pgp = require('pg-promise')();
+const db = require('../database');
+
+// const {hash, genSalt} = require('bcryptjs');
+// const bcrypt = require('bcryptjs');
+
+// Middleware given an email in the body, retireves the given admin
+// account or returns an error
+const getAdminByEmail = async (req, res, next) => {
+  try {
+    const data = await db.oneOrNone('SELECT * FROM Admins WHERE email = $1', [
+      req.body.email,
+    ]);
+
+    if (data) {
+      res.locals.admin = data;
+
+      next();
+    } else {
+      res.status(401).json({message: 'Email not found.'});
+    }
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({error: 'Internal Server Error'});
+  }
+};
+
+// Middleware to create a new admin account.
+// If used, should be an admin route. i.e. allow Lluvia 
+// to create a new admin account if wanted.
+const createAdmin = (name, email, password) => {
+  const salt = bcrypt.genSaltSync(10);
+  const hash = bcrypt.hashSync(password, salt);
+
+  return db.one(
+      'INSERT INTO Admins (name, email, password) VALUES ($1, $2, $3) RETURNING *',
+      [name, email, hash],
+  );
+};
+
+module.exports = {getAdminByEmail, createAdmin};

--- a/backend/controllers/AuthController.js
+++ b/backend/controllers/AuthController.js
@@ -58,7 +58,7 @@ const verifyAdminToken = async (req, res, next) => {
 
 // Returns a middleware to verify the user has the correct permissions.
 // Setting a route that only admins can access.
-// USAGE: router.get('/route', verify('admin'), controller);
+// USAGE: router.get('/route', verify('admin'), controller.method);
 const verify = (privilege) => {
   if (privilege === 'admin') {
     // Check the admin token

--- a/backend/controllers/AuthController.js
+++ b/backend/controllers/AuthController.js
@@ -1,6 +1,8 @@
 const jwt = require('jsonwebtoken');
 
-// This middleware will be used to sign the token after a user logs in
+// TODO: Set cookies to secure when https is ready?
+
+// This middleware will be used to sign the token after a vendor logs in
 const signToken = async (req, res, next) => {
   // Sign the token with JWT_SECRET
   const token = jwt.sign(res.locals.vendor, process.env.JWT_SECRET);
@@ -10,7 +12,7 @@ const signToken = async (req, res, next) => {
   next();
 };
 
-// This middleware will be used to verify the token sent by the client
+// This middleware will be used to verify the token sent by the vendor
 const verifyToken = async (req, res, next) => {
   // Retrieve the token from the cookie
   const token = req.cookies.auth;
@@ -27,4 +29,47 @@ const verifyToken = async (req, res, next) => {
   });
 };
 
-module.exports = {signToken, verifyToken};
+// This middleware will be used to sign the token after an admin logs in
+const signAdminToken = async (req, res, next) => {
+  // Sign the token with JWT_SECRET
+  const token = jwt.sign(res.locals.admin, process.env.JWT_SECRET);
+
+  // Return the token in a cookie
+  res.cookie('auth_pim', token, {httpOnly: true, secure: false});
+
+  next();
+};
+
+const verifyAdminToken = async (req, res, next) => {
+  // Retrieve the token from the cookie
+  const token = req.cookies.auth_pim;
+
+  // Verify the token with JWT_SECRET
+  jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
+    if (err) {
+      return res.status(401).json({message: 'Unauthorized'});
+    } else {
+      // Add the decoded object to res.locals
+      res.locals.admin = decoded;
+      next();
+    }
+  });
+};
+
+// Returns a middleware to verify the user has the correct permissions.
+// Setting a route that only admins can access.
+// USAGE: router.get('/route', verify('admin'), controller);
+const verify = (privilege) => {
+  if (privilege === 'admin') {
+    // Check the admin token
+    return verifyAdminToken;
+  } else if (privilege === 'vendor') {
+    // Check the vendor token
+    return verifyToken;
+  } else {
+    // You shouldn't need to set privilege for any other use case.
+    throw new Error('Privilege should be either vendor or admin.');
+  }
+};
+
+module.exports = {signToken, verifyToken, verifyAdminToken, signAdminToken, verify};

--- a/backend/controllers/EventController.js
+++ b/backend/controllers/EventController.js
@@ -37,11 +37,14 @@ const getEventById = async (req, res, next) => {
 const createEvent = async (req, res, next) => {
   const {name, location, datetime, description, capacity} = req.body;
   try {
-    await db.none(`
+    const event = await db.one(`
       INSERT INTO Events (name, location, datetime, description, vendor_capacity)
       VALUES ($1, $2, $3, $4, $5)
       RETURNING *;
     `, [name, location, datetime, description, capacity]);
+
+    // Returns the created event
+    res.locals.data = event;
 
     next();
   } catch (error) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -27,9 +27,11 @@ app.use(cookieParser());
 // Import router objects and direct the app to use them
 const VendorRouter = require('./routes/VendorRouter');
 const EventRouter = require('./routes/EventRouter');
+const AdminRouter = require('./routes/AdminRouter');
 
 app.use('/vendors', VendorRouter);
 app.use('/events', EventRouter);
+app.use('/admins', AdminRouter);
 
 app.get('/', (req, res) => {
   res.status(202).send('Hello World!');

--- a/backend/middleware/successResponse.js
+++ b/backend/middleware/successResponse.js
@@ -1,7 +1,7 @@
 // successResponse.js
 function sendSuccessResponse(req, res) {
   if (res.locals.data) {
-    console.log('Data in res.locals', res.locals.data);
+    // console.log('Data in res.locals', res.locals.data);
     res.status(200).json(res.locals.data);
   } else {
     // Fallback if no data is set in res.locals, but middleware is called

--- a/backend/routes/AdminRouter.js
+++ b/backend/routes/AdminRouter.js
@@ -3,7 +3,7 @@ const {
   signAdminToken,
   verify,
 } = require('../controllers/AuthController');
-const {getAdminByEmail} = require('../controllers/AdminController');
+const {getAdminByEmail, createAdminMiddleware} = require('../controllers/AdminController');
 
 // Import express
 const express = require('express');
@@ -16,8 +16,8 @@ router.post('/login', getAdminByEmail, signAdminToken, (req, res) => {
 });
 
 // UNFINISHED: Create an admin account
-// router.post('/', verify('admin'), signAdminToken, (req, res) => {
-//     res.status(200).json({status: 'success'});
+// router.post('/', createAdminMiddleware, (req, res) => {
+//   res.status(200).json({status: 'success', admin: res.locals.data});
 // });
 
 module.exports = router;

--- a/backend/routes/AdminRouter.js
+++ b/backend/routes/AdminRouter.js
@@ -1,0 +1,23 @@
+const {
+  verifyAdminToken,
+  signAdminToken,
+  verify,
+} = require('../controllers/AuthController');
+const {getAdminByEmail} = require('../controllers/AdminController');
+
+// Import express
+const express = require('express');
+
+// Create a router for admin authentication
+const router = express.Router();
+
+router.post('/login', getAdminByEmail, signAdminToken, (req, res) => {
+  res.status(200).json({status: 'success'});
+});
+
+// UNFINISHED: Create an admin account
+// router.post('/', verify('admin'), signAdminToken, (req, res) => {
+//     res.status(200).json({status: 'success'});
+// });
+
+module.exports = router;

--- a/backend/routes/EventRouter.js
+++ b/backend/routes/EventRouter.js
@@ -7,6 +7,7 @@ const {
   updateEvent,
 } = require('../controllers/EventController');
 const sendSuccessResponse = require('../middleware/successResponse');
+const {verify} = require('../controllers/AuthController');
 
 // Get all events
 router.get('/', getAllEvents, sendSuccessResponse);
@@ -15,9 +16,9 @@ router.get('/', getAllEvents, sendSuccessResponse);
 router.get('/:event_id', getEventById, sendSuccessResponse);
 
 // Create a new event
-router.post('/', createEvent, sendSuccessResponse);
+router.post('/', verify('admin'), createEvent, sendSuccessResponse);
 
 // Update an existing event
-router.put('/:event_id', updateEvent, sendSuccessResponse);
+router.put('/:event_id', verify('admin'), updateEvent, sendSuccessResponse);
 
 module.exports = router;

--- a/backend/routes/VendorRouter.js
+++ b/backend/routes/VendorRouter.js
@@ -13,8 +13,8 @@ const {
 } = require('../controllers/VendorController');
 const sendSuccessResponse = require('../middleware/successResponse');
 const {
-  verifyToken,
   signToken,
+  verify,
 } = require('../controllers/AuthController');
 
 // Logs in vendor
@@ -32,16 +32,16 @@ router.post('/', createVendor, (req, res) => {
 });
 
 // Create Vendor event request
-router.post('/events/request', createEventRequest, sendSuccessResponse);
+router.post('/events/request', verify('vendor'), createEventRequest, sendSuccessResponse);
 
 // Get Vendor event request
-router.get('/events/request', getEventRequest, sendSuccessResponse);
+router.get('/events/request', verify('admin'), getEventRequest, sendSuccessResponse);
 
 // Edit vendor by id
 // This probably should be an admin-protected route. How does that work?
-router.put('/:vendorId', verifyToken, updateVendor, sendSuccessResponse);
+router.put('/:vendorId', verify('admin'), updateVendor, sendSuccessResponse);
 
 // Route for vendor to update themself. ID is retrieved from the token.
-router.put('/', verifyToken, updateAuthenticatedVendor, sendSuccessResponse);
+router.put('/', verify('vendor'), updateAuthenticatedVendor, sendSuccessResponse);
 
 module.exports = router;


### PR DESCRIPTION
A couple of updates to authorization in this branch.

* Added another cookie for authenticating admins.
* Made it so that authorization cookies are kept up to date with data in the database
* created the function `verify` in `AuthController.js`. The `verify` function protects a route for vendors or admins only depending on input. `verify('admin')` returns a middleware function that checks the admin auth token. Use this function to protect vendor (`verify('vendor')`) or admin routes.